### PR TITLE
Fix ExperimentalSpreadProperty causing errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = {
                                 prop.value.type === "FunctionExpression") {
                             return prop;
                         }
+                        if (prop.type === 'ExperimentalSpreadProperty') {
+                            return prop;
+                        }
                         var lastPropId, propId;
                         if (prop.key.type === "Identifier") {
                             lastPropId = lastProp.key.name;


### PR DESCRIPTION
Without this, if you had a object like this:

    var a = {}
    var b = { ...a };

It would throw an error:

    Cannot read property 'type' of undefined
    TypeError: Cannot read property 'type' of undefined
        at .../eslint-plugin-sorting/index.js:19:37
        at Array.reduce (native)
        at EventEmitter.ObjectExpression (.../eslint-plugin-sorting/index.js:13:37)

This fixes it. By ignoring the ExperimentalSpreadProperty altogether.

Fixes #11 