### PR TITLE
ExperimentalSpreadProperty, and babel-eslint

### DIFF
--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -21,7 +21,8 @@ module.exports = {
                     if (opts.ignoreMethods && current.value.type === "FunctionExpression") {
                         return current;
                     }
-                    if (current.type === "ExperimentalSpreadProperty") {
+                    if (current.type === "ExperimentalSpreadProperty" ||
+                        prev.type === "ExperimentalSpreadProperty") {
                         return current;
                     }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "homepage": "https://github.com/jacobrask/eslint-plugin-sorting",
   "devDependencies": {
+    "babel-eslint": "^6.0.4",
+    "eslint": "^2.12.0",
     "eslint-config-eslint": "^3.0.0",
     "mocha": "^2.5.3"
   }

--- a/tests/lib/rules/sort-object-props.js
+++ b/tests/lib/rules/sort-object-props.js
@@ -17,7 +17,8 @@ ruleTester.run("sort-object-props", rule, {
         "var obj = { a: true, b: true }",
         "var obj = { 1: 'foo', a: 'bar', c: false }",
         "var obj = { '1': 'foo', a: 'bar', c: false }",
-        "var obj = { A: 'eggs', a: 'spam' }"
+        "var obj = { A: 'eggs', a: 'spam' }",
+        { code: "var a = { a:'a' }; var b = {a:1, ...a, b:2}", "parser": "babel-eslint", rules: {strict: 0} }
     ],
     invalid: [
         { code: "var obj = { b: 'spam', a: 'eggs', c: 'foo' }", errors: [ expectedError ] },


### PR DESCRIPTION
Fixes the rule to parse ExperimentalSpreadProperty

Adds babel-eslint as a parser

Adds a test which uses babel-eslint

Update dependencies

Rewrite of #14