### PR TITLE
Fix Computed property CallExpression

### DIFF
--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -25,6 +25,10 @@ module.exports = {
                         prev.type === "ExperimentalSpreadProperty") {
                         return current;
                     }
+                    if (current.key.type === "CallExpression" ||
+                        prev.key.type === "CallExpression") {
+                        return current;
+                    }
 
                     var prevKey = getKey(prev);
                     var currentKey = getKey(current);

--- a/tests/lib/rules/sort-object-props.js
+++ b/tests/lib/rules/sort-object-props.js
@@ -18,7 +18,8 @@ ruleTester.run("sort-object-props", rule, {
         "var obj = { 1: 'foo', a: 'bar', c: false }",
         "var obj = { '1': 'foo', a: 'bar', c: false }",
         "var obj = { A: 'eggs', a: 'spam' }",
-        { code: "var a = { a:'a' }; var b = {a:1, ...a, b:2}", "parser": "babel-eslint", rules: {strict: 0} }
+        { code: "var a = { a:'a' }; var b = {a:1, ...a, b:2}", "parser": "babel-eslint", rules: {strict: 0} },
+        { code: "var a = { [a()]: 'a' }", "parser": "babel-eslint", rules: {strict: 0} }
     ],
     invalid: [
         { code: "var obj = { b: 'spam', a: 'eggs', c: 'foo' }", errors: [ expectedError ] },


### PR DESCRIPTION
This fails:

    { [a()]: 'a' }

This commit fixes it