### PR TITLE
Ignored types

### DIFF
--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var checkIgnoredTypes = require("../util/check-ignored-types");
+
 /**
  * @param {Property} prop ObjectExpression property.
  *
@@ -18,24 +20,13 @@ module.exports = {
         return {
             ObjectExpression: function(node) {
                 node.properties.reduce(function(prev, current) {
-                    if (opts.ignoreMethods && current.value.type === "FunctionExpression") {
-                        return current;
-                    }
-                    if (current.type === "ExperimentalSpreadProperty" ||
-                        prev.type === "ExperimentalSpreadProperty") {
-                        return current;
-                    }
-                    if (current.key.type === "CallExpression" ||
-                        prev.key.type === "CallExpression") {
-                        return current;
-                    }
-                    if (current.key.type === "ConditionalExpression" ||
-                        prev.key.type === "ConditionalExpression") {
+                    if (checkIgnoredTypes(current, prev, opts)) {
                         return current;
                     }
 
                     var prevKey = getKey(prev);
                     var currentKey = getKey(current);
+
                     if (opts.ignoreCase && prev) {
                         prevKey = prevKey.toLowerCase();
                         currentKey = currentKey.toLowerCase();

--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -29,6 +29,10 @@ module.exports = {
                         prev.key.type === "CallExpression") {
                         return current;
                     }
+                    if (current.key.type === "ConditionalExpression" ||
+                        prev.key.type === "ConditionalExpression") {
+                        return current;
+                    }
 
                     var prevKey = getKey(prev);
                     var currentKey = getKey(current);

--- a/lib/util/check-ignored-types.js
+++ b/lib/util/check-ignored-types.js
@@ -1,0 +1,57 @@
+"use strict";
+
+var ignoredTypes = [{
+    nodeType: "node",
+    type: "ExperimentalSpreadProperty"
+}, {
+    nodeType: "key",
+    type: "CallExpression"
+}, {
+    nodeType: "key",
+    type: "ConditionalExpression"
+}, {
+    nodeType: "value",
+    type: "FunctionExpression",
+    flag: "ignoreMethods"
+}];
+
+/**
+ * Checks node whether a certain type should be ignored or not.
+ * @param {Node} curr: Current node.
+ * @param {Node} prev: Previous node.
+ * @param {object} flags: Only ignores a type if its corresponding {flag:xxx} property found in this `flags` object
+ * @returns {Boolean} true/false value
+ */
+module.exports = function checkIgnoredType(curr, prev, flags) {
+    for (var i = 0, length = ignoredTypes.length; i < length; i++) {
+        var ignoredType = ignoredTypes[i];
+        var type = ignoredType.type;
+        var flag = ignoredType.flag;
+
+        if (flags && flag && !flags[flag]) {
+            continue;
+        }
+
+        var node = {};
+        if (ignoredType.nodeType === "node") {
+            node.curr = curr;
+            node.prev = prev;
+        } else if (ignoredType.nodeType === "key") {
+            node.curr = curr.key;
+            node.prev = prev.key;
+        } else if (ignoredType.nodeType === "value") {
+            node.curr = curr.value;
+            node.prev = prev.value;
+        } else {
+            continue;
+        }
+
+        if (type === node.curr.type) {
+            return true;
+        }
+        if (type === node.prev.type) {
+            return true;
+        }
+    }
+    return false;
+};

--- a/tests/lib/rules/sort-object-props.js
+++ b/tests/lib/rules/sort-object-props.js
@@ -19,7 +19,8 @@ ruleTester.run("sort-object-props", rule, {
         "var obj = { '1': 'foo', a: 'bar', c: false }",
         "var obj = { A: 'eggs', a: 'spam' }",
         { code: "var a = { a:'a' }; var b = {a:1, ...a, b:2}", "parser": "babel-eslint", rules: {strict: 0} },
-        { code: "var a = { [a()]: 'a' }", "parser": "babel-eslint", rules: {strict: 0} }
+        { code: "var a = { [a()]: 'a' }", "parser": "babel-eslint", rules: {strict: 0} },
+        { code: "var a = { [a?b:c]: d }", "parser": "babel-eslint", rules: {strict: 0} }
     ],
     invalid: [
         { code: "var obj = { b: 'spam', a: 'eggs', c: 'foo' }", errors: [ expectedError ] },


### PR DESCRIPTION
Found another property that caused failure: `{ [a?b:c]: d }`

Refactored all this ignore type logic into a separate function
