### PR TITLE
Handle more varieties of computed keys

### DIFF
--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -3,15 +3,63 @@
 var checkIgnoredTypes = require("../util/check-ignored-types");
 
 /**
- * @param {Property} prop ObjectExpression property.
- *
+ * Recursively converts Nodes to strings so they can be sorted
+ * @param {Node} node: Babel AST Node
+ * @returns {String} Node value as a string
+ */
+function nodeToString(node) {
+    switch (node.type) {
+        case ("BinaryExpression"): {
+            return nodeToString(node.left) + node.operator.toString() + nodeToString(node.right);
+        }
+        case ("CallExpression"): {
+            var args = node.arguments.map(function(arg) {
+                return nodeToString(arg);
+            }).toString();
+            return nodeToString(node.callee) + "(" + args + ")";
+        }
+        case ("ConditionalExpression"): {
+            return nodeToString(node.test) + "?" + nodeToString(node.consequent) + ":" + nodeToString(node.alternate);
+        }
+        case ("Identifier"): {
+            return node.name.toString();
+        }
+        case ("Literal"): {
+            return node.value.toString();
+        }
+        case ("MemberExpression"): {
+            return nodeToString(node.object) + "[" + nodeToString(node.property) + "]";
+        }
+        case ("TemplateElement"): {
+            return node.value.raw.toString();
+        }
+        case ("TemplateLiteral"): {
+            // interleave quasis with expressions
+            var s = [];
+            node.quasis.forEach(function(quasi, i) {
+                if (quasi.value.raw) {
+                    s.push(nodeToString(quasi));
+                }
+                var expression = node.expressions[i];
+                if (expression) {
+                    s.push(nodeToString(expression));
+                }
+            });
+            return s.join("");
+        }
+        default: {
+            // Silently ignore Nodes with types we don't handle
+            return "";
+        }
+    }
+}
+
+/**
+ * @param {Property} prop: ObjectExpression property.
  * @returns {String} Property key as a string.
  */
 function getKey(prop) {
-    if (prop.key.type === "Literal") {
-        return prop.key.value.toString();
-    }
-    return prop.key.name.toString();
+    return nodeToString(prop.key);
 }
 
 module.exports = {

--- a/lib/util/check-ignored-types.js
+++ b/lib/util/check-ignored-types.js
@@ -4,18 +4,6 @@ var ignoredTypes = [{
     nodeType: "node",
     type: "ExperimentalSpreadProperty"
 }, {
-    nodeType: "key",
-    type: "BinaryExpression"
-}, {
-    nodeType: "key",
-    type: "CallExpression"
-}, {
-    nodeType: "key",
-    type: "ConditionalExpression"
-}, {
-    nodeType: "key",
-    type: "MemberExpression"
-}, {
     nodeType: "value",
     type: "FunctionExpression",
     flag: "ignoreMethods"


### PR DESCRIPTION
- Recursively converts Nodes in the `key` field to strings so we can sort more computed properties.
- Removes a handful of ignored types now that we can support them
