### PR TITLE
 Configuration for custom sorting or ignored properties

### DIFF
--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -62,14 +62,24 @@ function getKey(prop) {
     return nodeToString(prop.key);
 }
 
-function isLesserThan(firstKey, secondKey) {
-    if (firstKey === 'type') {
-        return secondKey !== 'type';
+/**
+ * @param {Object} opts: ESLint options.
+ * @param {string} firstKey: An object field name.
+ * @param {string} secondKey: An other object field name.
+ * @returns {boolean} If firstKey is lesser than or equal to secondKey.
+ */
+function isLesserThanOrEqual(opts, firstKey, secondKey) {
+    if (opts.customSortOrder) {
+        var start = opts.customSortOrder.start || [];
+        var end = opts.customSortOrder.end || [];
+        if (start.indexOf(firstKey) !== -1 || end.indexOf(secondKey) !== -1) {
+            return true;
+        }
+        if (start.indexOf(secondKey) !== -1 || end.indexOf(firstKey) !== -1) {
+            return false;
+        }
     }
-    if (secondKey === 'type') {
-        return false;
-    }
-    return firstKey < secondKey;
+    return firstKey <= secondKey;
 }
 
 module.exports = {
@@ -94,7 +104,7 @@ module.exports = {
                         return current;
                     }
 
-                    if (isLesserThan(currentKey, prevKey)) {
+                    if (!isLesserThanOrEqual(opts, prevKey, currentKey)) {
                         context.report(current, "Property names in an object literal should be sorted alphabetically");
                     }
                     return current;

--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -62,6 +62,16 @@ function getKey(prop) {
     return nodeToString(prop.key);
 }
 
+function isLesserThan(firstKey, secondKey) {
+    if (firstKey === 'type') {
+        return secondKey !== 'type';
+    }
+    if (secondKey === 'type') {
+        return false;
+    }
+    return firstKey < secondKey;
+}
+
 module.exports = {
     create: function(context) {
         var opts = context.options[0] || {};
@@ -84,7 +94,7 @@ module.exports = {
                         return current;
                     }
 
-                    if (currentKey < prevKey) {
+                    if (isLesserThan(currentKey, prevKey)) {
                         context.report(current, "Property names in an object literal should be sorted alphabetically");
                     }
                     return current;


### PR DESCRIPTION
This pull-request aims to resolve #22 . As suggested, it adds an option:
```
"customSortOrder": {start: ["foo", "bar], end: ["bla]}
```
to force having `foo` and `bar` as first elements, and `bla` as last element.