### PR TITLE
feat(options): add ignoreMethodSiblings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ In the plugins section of your `.eslintrc`, add `sorting`.
     "sorting"
   ],
   "rules": {
-    "sorting/sort-object-props": [ 1, { "ignoreCase": true, "ignoreMethods": false } ]
+    "sorting/sort-object-props": [ 1, {
+      "ignoreCase": true,
+      "ignoreMethods": false,
+      "ignoreMethodSiblings": false
+    } ]
   }
 }
 ```
@@ -53,6 +57,16 @@ OK if `ignoreMethods: true`
 ```js
 var Foo = {
   b: function() {},
+  a: function() {}
+};
+```
+
+OK if `ignoreMethodSiblings: true`
+
+```js
+var Foo = {
+  c: 1,
+  b: 2,
   a: function() {}
 };
 ```

--- a/index.js
+++ b/index.js
@@ -7,7 +7,11 @@ module.exports = {
     configs: {
         recommended: {
             rules: {
-                "sort-object-props": [1, { ignoreCase: true, ignoreMethods: false }]
+                "sort-object-props": [1, {
+                    ignoreCase: true,
+                    ignoreMethods: false,
+                    ignoreMethodSiblings: false
+                }]
             }
         }
     }

--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -87,11 +87,24 @@ function isLesserThanOrEqual(opts, firstKey, secondKey, nodeParentName) {
     return firstKey <= secondKey;
 }
 
+/**
+ * @param {Object} node: ObjectExpression node.
+ * @returns {boolean} `true` if node has properties that are methods.
+ */
+function hasMethods(node) {
+    return node.properties.some(function(p) {
+        return p.value.type === "FunctionExpression" || p.value.type === "ArrowFunctionExpression";
+    });
+}
+
 module.exports = {
     create: function(context) {
         var opts = context.options[0] || {};
         return {
             ObjectExpression: function(node) {
+                if (opts.ignoreMethodSiblings && hasMethods(node)) {
+                    return;
+                }
                 node.properties.reduce(function(prev, current) {
                     if (checkIgnoredTypes(current, prev, opts)) {
                         return current;

--- a/tests/lib/rules/sort-object-props.js
+++ b/tests/lib/rules/sort-object-props.js
@@ -12,11 +12,13 @@ var expectedError = {
 /**
  * Wraps a block of code and that needs to be tested with babel-eslint
  * @param {String} code: Code to be tested
+ * @param {Object} options: Options to test with
  * @returns {object} Object that will be tested
  */
-function transpile(code) {
+function transpile(code, options) {
     return {
         code: code,
+        options: options,
         parser: "babel-eslint",
         rules: {strict: 0}
     };
@@ -70,7 +72,11 @@ ruleTester.run("sort-object-props", rule, {
         transpile("var conditional = { [(a !== b)?b:c]: d, [(a === b)?b:c]: d,  }"),
         transpile("var member = {[a.b]: c}"),
         transpile("var nestedMember = {[a[b][c]]: d, [b[a][c]]: d}"),
-        transpile("var binaryExpression = { [a + b]: c}")
+        transpile("var binaryExpression = { [a + b]: c}"),
+        transpile("var withMethods = { b: function() {}, a: function() {} }", [ { ignoreMethods: true } ]),
+        transpile("var withMethodSiblings = { c: 1, b: 2, a: function() {} }", [ { ignoreMethodSiblings: true } ]),
+        transpile("var withMethodSiblings = { c: 1, b: 2, a: () => {} }", [ { ignoreMethodSiblings: true } ]),
+        transpile("var withMethodSiblings = { c: 1, b: 2, a() {} }", [ { ignoreMethodSiblings: true } ])
     ],
     invalid: [
         expectError("var obj = { b: 'spam', a: 'eggs', c: 'foo' }"),
@@ -78,6 +84,8 @@ ruleTester.run("sort-object-props", rule, {
         expectError("var obj = { a: 'foo', 1: 'spam' }"),
         expectError("var obj = { z: 'foo', a: 'spam' }"),
         expectError("var obj = { a: true, A: false }"),
+        expectError("var withMethods = { b: function() {}, a: function() {} }"),
+        expectError("var withMethodSiblings = { b: 2, a: function() {} }"),
         transpileExpectError("var functionCallWithArg = { [a('banana')]: 'a', [a('apple')]: 'b' }"),
         transpileExpectError("var functionCallWithArgs = { [a('apple','orange')]: 'a', [a('apple','banana')]: 'b' }"),
         transpileExpectError("var conditional = { [c?b:a]: d, [a?b:c]: d }"),


### PR DESCRIPTION
In [mozilla/fxa-content-server](https://github.com/mozilla/fxa-content-server), we're depending on a very [out-of-date fork](https://github.com/shane-tomlinson/eslint-plugin-sorting/tree/feat-ignore-objects-with-methods) of this plugin, which has fallen behind the upstream changes significantly. If possible, we'd like to get back to using a vanilla release from npm.

This PR contains the only substantive change we need for that to happen, in the form of an extra option called `ignoreMethodSiblings`.

Is this option (or some variation of it), something you'd be interested in merging?