### PR TITLE
fix(options): handle spread operator with ignoreMethodSiblings option

### DIFF
--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -93,7 +93,7 @@ function isLesserThanOrEqual(opts, firstKey, secondKey, nodeParentName) {
  */
 function hasMethods(node) {
     return node.properties.some(function(p) {
-        return p.value.type === "FunctionExpression" || p.value.type === "ArrowFunctionExpression";
+        return !!p.value || p.value.type === "FunctionExpression" || p.value.type === "ArrowFunctionExpression";
     });
 }
 

--- a/tests/lib/rules/sort-object-props.js
+++ b/tests/lib/rules/sort-object-props.js
@@ -75,7 +75,7 @@ ruleTester.run("sort-object-props", rule, {
         transpile("var binaryExpression = { [a + b]: c}"),
         transpile("var withMethods = { b: function() {}, a: function() {} }", [ { ignoreMethods: true } ]),
         transpile("var withMethodSiblings = { c: 1, b: 2, a: function() {} }", [ { ignoreMethodSiblings: true } ]),
-        transpile("var withMethodSiblings = { c: 1, b: 2, a: () => {} }", [ { ignoreMethodSiblings: true } ]),
+        transpile("var withMethodSiblings = { c: 1, b: 2, ...a, a: () => {} }", [ { ignoreMethodSiblings: true } ]),
         transpile("var withMethodSiblings = { c: 1, b: 2, a() {} }", [ { ignoreMethodSiblings: true } ])
     ],
     invalid: [


### PR DESCRIPTION
Apologies, I introduced a bug in #26 when I assumed the existence of `p.value`. But it's `undefined` when traversing the spread operator, possibly there are other ways to trigger it too.

This PR fixes it with an extra condition and modifies one of the tests to trigger the error case.

r?