### PR TITLE
fix(options): fix doubly-negated boolean in ignoreMethodSiblings check

### DIFF
--- a/lib/rules/sort-object-props.js
+++ b/lib/rules/sort-object-props.js
@@ -93,7 +93,7 @@ function isLesserThanOrEqual(opts, firstKey, secondKey, nodeParentName) {
  */
 function hasMethods(node) {
     return node.properties.some(function(p) {
-        return !!p.value || p.value.type === "FunctionExpression" || p.value.type === "ArrowFunctionExpression";
+        return !p.value || p.value.type === "FunctionExpression" || p.value.type === "ArrowFunctionExpression";
     });
 }
 

--- a/tests/lib/rules/sort-object-props.js
+++ b/tests/lib/rules/sort-object-props.js
@@ -75,7 +75,7 @@ ruleTester.run("sort-object-props", rule, {
         transpile("var binaryExpression = { [a + b]: c}"),
         transpile("var withMethods = { b: function() {}, a: function() {} }", [ { ignoreMethods: true } ]),
         transpile("var withMethodSiblings = { c: 1, b: 2, a: function() {} }", [ { ignoreMethodSiblings: true } ]),
-        transpile("var withMethodSiblings = { c: 1, b: 2, ...a, a: () => {} }", [ { ignoreMethodSiblings: true } ]),
+        transpile("var withMethodSiblings = { ...d, c: 1, b: 2, a: () => {} }", [ { ignoreMethodSiblings: true } ]),
         transpile("var withMethodSiblings = { c: 1, b: 2, a() {} }", [ { ignoreMethodSiblings: true } ])
     ],
     invalid: [


### PR DESCRIPTION
Apologies once again, I introduced yet another bug yesterday in #27, and the test I wrote didn't catch it.

The `!!` the should have been a `!`, but instead meant every node with a `value` property caused `hasMethods` to short-circuit to `true`. The test case would have caught it if the spread operator was the first item, but it wan't so things appeared to work. Booleans are hard, sigh.

Anyway, fixed properly here and the test is modified accordingly.

r?